### PR TITLE
Update models

### DIFF
--- a/erdkotlin/src/main/java/com/elrond/erdkotlin/data/DataMappers.kt
+++ b/erdkotlin/src/main/java/com/elrond/erdkotlin/data/DataMappers.kt
@@ -52,32 +52,11 @@ internal fun GetAddressTransactionsResponse.TransactionOnNetworkData.toDomain() 
         round = round,
         searchOrder = searchOrder,
         fee = fee,
-        scResults = scResults?.map { scResult -> scResult.toDomain() },
         hyperblockNonce = hyperblockNonce
     )
 
-internal fun GetAddressTransactionsResponse.TransactionOnNetworkData.ScResult.toDomain() =
-    TransactionOnNetwork.ScResult(
-        hash = hash,
-        nonce = nonce,
-        gasLimit = gasLimit,
-        gasPrice = gasPrice,
-        value = value,
-        sender = sender,
-        receiver = receiver,
-        relayedValue = relayedValue,
-        data = data,
-        prevTxHash = prevTxHash,
-        originalTxHash = originalTxHash,
-        callType = callType,
-        relayerAddress = relayerAddress,
-        code = code,
-        codeMetadata = codeMetadata,
-        returnMessage = returnMessage,
-        originalSender = originalSender,
-    )
-
-internal fun GetTransactionInfoResponse.TransactionInfoData.toDomain() = TransactionInfo(
+internal fun GetTransactionInfoResponse.TransactionInfoData.toDomain(txHash: String) = TransactionInfo(
+    txHash = txHash,
     type = type,
     nonce = nonce,
     round = round,
@@ -94,10 +73,26 @@ internal fun GetTransactionInfoResponse.TransactionInfoData.toDomain() = Transac
     sourceShard = sourceShard,
     destinationShard = destinationShard,
     blockNonce = blockNonce,
+    timestamp = timestamp,
     miniBlockHash = miniBlockHash,
     blockHash = blockHash,
     status = status,
-    hyperblockNonce = hyperblockNonce
+    hyperblockNonce = hyperblockNonce,
+    smartContractResults = smartContractResults?.map { scr ->
+        TransactionInfo.ScResult(
+            hash = scr.hash,
+            nonce = scr.nonce,
+            value = scr.value,
+            receiver = Address.fromBech32(scr.receiver),
+            sender = Address.fromBech32(scr.sender),
+            data = scr.data,
+            prevTxHash = scr.prevTxHash,
+            originalTxHash = scr.originalTxHash,
+            gasLimit = scr.gasLimit,
+            gasPrice = scr.gasPrice,
+            callType = scr.callType
+        )
+    },
 )
 
 internal fun QueryContractResponse.Data.toDomain() = QueryContractOutput(

--- a/erdkotlin/src/main/java/com/elrond/erdkotlin/data/account/responses/GetAddressTransactionsResponse.kt
+++ b/erdkotlin/src/main/java/com/elrond/erdkotlin/data/account/responses/GetAddressTransactionsResponse.kt
@@ -26,28 +26,6 @@ internal data class GetAddressTransactionsResponse(
         val round: Long,
         val searchOrder: Long,
         val fee: String,
-        val scResults: List<ScResult>?,
         val hyperblockNonce: Long?
-    ) {
-        // source : https://github.com/ElrondNetwork/elrond-go/blob/2be09d2377993cda87cef7b4167c915d8ea5f163/data/transaction/apiTransactionResult.go#L57
-        data class ScResult(
-            val hash: String?,
-            val nonce: Long,
-            val gasLimit: Long,
-            val gasPrice: Long,
-            val value: BigInteger,
-            val sender: String,
-            val receiver: String,
-            val relayedValue: String?,
-            val data: String?,
-            val prevTxHash: String,
-            val originalTxHash: String,
-            val callType: String,
-            val relayerAddress: String?,
-            val code: String?,
-            val codeMetadata: String?,
-            val returnMessage: String?,
-            val originalSender: String?,
-        )
-    }
+    )
 }

--- a/erdkotlin/src/main/java/com/elrond/erdkotlin/data/api/ElrondProxy.kt
+++ b/erdkotlin/src/main/java/com/elrond/erdkotlin/data/api/ElrondProxy.kt
@@ -66,10 +66,10 @@ internal class ElrondProxy(
         return elrondClient.doPost("transaction/cost", transaction.serialize())
     }
 
-    fun getTransactionInfo(txHash: String, sender: Address?, withResults: Boolean): ElrondClient.ResponseBase<GetTransactionInfoResponse> {
+    fun getTransactionInfo(txHash: String, sender: Address?, withResults: Boolean?): ElrondClient.ResponseBase<GetTransactionInfoResponse> {
         val params = ArgFormatter().apply {
             addArg(sender) { "sender=${it.bech32}" }
-            addArg(withResults) { "withResults=true" }
+            addArg(withResults) { "withResults=$it" }
         }
         return elrondClient.doGet("transaction/$txHash$params")
     }

--- a/erdkotlin/src/main/java/com/elrond/erdkotlin/data/api/ElrondProxy.kt
+++ b/erdkotlin/src/main/java/com/elrond/erdkotlin/data/api/ElrondProxy.kt
@@ -139,6 +139,4 @@ internal class ElrondProxy(
             return args
         }
     }
-
-
 }

--- a/erdkotlin/src/main/java/com/elrond/erdkotlin/data/api/ElrondProxy.kt
+++ b/erdkotlin/src/main/java/com/elrond/erdkotlin/data/api/ElrondProxy.kt
@@ -66,12 +66,12 @@ internal class ElrondProxy(
         return elrondClient.doPost("transaction/cost", transaction.serialize())
     }
 
-    fun getTransactionInfo(txHash: String, sender: Address?): ElrondClient.ResponseBase<GetTransactionInfoResponse> {
-        val senderAddress = when (sender){
-            null -> ""
-            else -> "?sender=${sender.bech32}"
+    fun getTransactionInfo(txHash: String, sender: Address?, withResults: Boolean): ElrondClient.ResponseBase<GetTransactionInfoResponse> {
+        val params = ArgFormatter().apply {
+            addArg(sender) { "sender=${it.bech32}" }
+            addArg(withResults) { "withResults=true" }
         }
-        return elrondClient.doGet("transaction/$txHash$senderAddress")
+        return elrondClient.doGet("transaction/$txHash$params")
     }
 
     fun getTransactionStatus(txHash: String, sender: Address?): ElrondClient.ResponseBase<GetTransactionStatusResponse> {
@@ -118,5 +118,27 @@ internal class ElrondProxy(
     fun getAllIssuedEsdt(): ElrondClient.ResponseBase<GetAllIssuedEsdtResponse> {
         return elrondClient.doGet("network/esdts")
     }
+
+    /** Private **/
+
+    private class ArgFormatter {
+        private var args = ""
+
+        fun <T> addArg(arg: T?, formatArg: (T) -> String) {
+            val prefix = when {
+                args.isEmpty() -> "?"
+                else -> "&"
+            }
+            args += when (arg){
+                null -> ""
+                else -> prefix + formatArg(arg)
+            }
+        }
+
+        override fun toString(): String {
+            return args
+        }
+    }
+
 
 }

--- a/erdkotlin/src/main/java/com/elrond/erdkotlin/data/transaction/TransactionRepositoryImpl.kt
+++ b/erdkotlin/src/main/java/com/elrond/erdkotlin/data/transaction/TransactionRepositoryImpl.kt
@@ -32,7 +32,7 @@ internal class TransactionRepositoryImpl(
         return requireNotNull(response.data).txGasUnits
     }
 
-    override fun getTransactionInfo(txHash: String, sender: Address?, withResults: Boolean): TransactionInfo {
+    override fun getTransactionInfo(txHash: String, sender: Address?, withResults: Boolean?): TransactionInfo {
         val response = elrondProxy.getTransactionInfo(txHash, sender, withResults)
         return requireNotNull(response.data).transaction.toDomain(txHash)
     }

--- a/erdkotlin/src/main/java/com/elrond/erdkotlin/data/transaction/TransactionRepositoryImpl.kt
+++ b/erdkotlin/src/main/java/com/elrond/erdkotlin/data/transaction/TransactionRepositoryImpl.kt
@@ -32,9 +32,9 @@ internal class TransactionRepositoryImpl(
         return requireNotNull(response.data).txGasUnits
     }
 
-    override fun getTransactionInfo(txHash: String, sender: Address?): TransactionInfo {
-        val response = elrondProxy.getTransactionInfo(txHash, sender)
-        return requireNotNull(response.data).transaction.toDomain()
+    override fun getTransactionInfo(txHash: String, sender: Address?, withResults: Boolean): TransactionInfo {
+        val response = elrondProxy.getTransactionInfo(txHash, sender, withResults)
+        return requireNotNull(response.data).transaction.toDomain(txHash)
     }
 
     override fun getTransactionStatus(txHash: String, sender: Address?): String {

--- a/erdkotlin/src/main/java/com/elrond/erdkotlin/data/transaction/responses/GetTransactionInfoResponse.kt
+++ b/erdkotlin/src/main/java/com/elrond/erdkotlin/data/transaction/responses/GetTransactionInfoResponse.kt
@@ -22,10 +22,26 @@ internal class GetTransactionInfoResponse(
         val sourceShard: Long,
         val destinationShard: Long,
         val blockNonce: Long,
+        val timestamp: Long,
         val miniBlockHash: String?,
         val blockHash: String?,
         val status: String,
-        val hyperblockNonce: Long?
+        val hyperblockNonce: Long?,
+        val smartContractResults: List<ScResult>?
+    )
+
+    data class ScResult(
+        val hash: String?,
+        val nonce: Long,
+        val value: BigInteger,
+        val receiver: String,
+        val sender: String,
+        val data: String?,
+        val prevTxHash: String,
+        val originalTxHash: String,
+        val gasLimit: Long,
+        val gasPrice: Long,
+        val callType: String
     )
 
 }

--- a/erdkotlin/src/main/java/com/elrond/erdkotlin/domain/esdt/management/TransferEsdtUsecase.kt
+++ b/erdkotlin/src/main/java/com/elrond/erdkotlin/domain/esdt/management/TransferEsdtUsecase.kt
@@ -20,6 +20,7 @@ class TransferEsdtUsecase internal constructor(
         wallet: Wallet,
         networkConfig: NetworkConfig,
         gasPrice: Long,
+        extraGasLimit: Long? = null, // <an appropriate amount for the method call>
         receiver: Address,
         tokenIdentifier: String,
         valueToTransfer: BigInteger,
@@ -42,7 +43,7 @@ class TransferEsdtUsecase internal constructor(
                 sender = account.address,
                 receiver = receiver,
                 value = ESDT_TRANSACTION_VALUE,
-                gasLimit = 500000L, // TODO + <an appropriate amount for the method call>
+                gasLimit = 500000L + (extraGasLimit ?: 0L),
                 gasPrice = gasPrice,
                 data = args.fold("ESDTTransfer") { it1, it2 -> "$it1@$it2" },
                 chainID = networkConfig.chainID,

--- a/erdkotlin/src/main/java/com/elrond/erdkotlin/domain/transaction/GetTransactionInfoUsecase.kt
+++ b/erdkotlin/src/main/java/com/elrond/erdkotlin/domain/transaction/GetTransactionInfoUsecase.kt
@@ -4,6 +4,6 @@ import com.elrond.erdkotlin.domain.wallet.models.Address
 
 class GetTransactionInfoUsecase internal constructor(private val transactionRepository: TransactionRepository) {
 
-    fun execute(txHash: String, sender: Address? = null) =
-        transactionRepository.getTransactionInfo(txHash, sender)
+    fun execute(txHash: String, sender: Address? = null, withResults: Boolean = false) =
+        transactionRepository.getTransactionInfo(txHash, sender, withResults)
 }

--- a/erdkotlin/src/main/java/com/elrond/erdkotlin/domain/transaction/GetTransactionInfoUsecase.kt
+++ b/erdkotlin/src/main/java/com/elrond/erdkotlin/domain/transaction/GetTransactionInfoUsecase.kt
@@ -4,6 +4,6 @@ import com.elrond.erdkotlin.domain.wallet.models.Address
 
 class GetTransactionInfoUsecase internal constructor(private val transactionRepository: TransactionRepository) {
 
-    fun execute(txHash: String, sender: Address? = null, withResults: Boolean = false) =
+    fun execute(txHash: String, sender: Address? = null, withResults: Boolean? = null) =
         transactionRepository.getTransactionInfo(txHash, sender, withResults)
 }

--- a/erdkotlin/src/main/java/com/elrond/erdkotlin/domain/transaction/TransactionRepository.kt
+++ b/erdkotlin/src/main/java/com/elrond/erdkotlin/domain/transaction/TransactionRepository.kt
@@ -34,7 +34,7 @@ internal interface TransactionRepository {
         Exceptions.CannotSerializeTransactionException::class,
         Exceptions.ProxyRequestException::class
     )
-    fun getTransactionInfo(txHash: String, sender: Address?, withResults: Boolean): TransactionInfo
+    fun getTransactionInfo(txHash: String, sender: Address?, withResults: Boolean?): TransactionInfo
 
     @Throws(
         IOException::class,

--- a/erdkotlin/src/main/java/com/elrond/erdkotlin/domain/transaction/TransactionRepository.kt
+++ b/erdkotlin/src/main/java/com/elrond/erdkotlin/domain/transaction/TransactionRepository.kt
@@ -34,7 +34,7 @@ internal interface TransactionRepository {
         Exceptions.CannotSerializeTransactionException::class,
         Exceptions.ProxyRequestException::class
     )
-    fun getTransactionInfo(txHash: String, sender: Address?): TransactionInfo
+    fun getTransactionInfo(txHash: String, sender: Address?, withResults: Boolean): TransactionInfo
 
     @Throws(
         IOException::class,

--- a/erdkotlin/src/main/java/com/elrond/erdkotlin/domain/transaction/models/TransactionInfo.kt
+++ b/erdkotlin/src/main/java/com/elrond/erdkotlin/domain/transaction/models/TransactionInfo.kt
@@ -4,6 +4,7 @@ import com.elrond.erdkotlin.domain.wallet.models.Address
 import java.math.BigInteger
 
 data class TransactionInfo(
+    val txHash: String,
     val type: String,
     val nonce: Long,
     val round: Long,
@@ -15,13 +16,31 @@ data class TransactionInfo(
     val receiverUsername: String?,
     val gasPrice: Long,
     val gasLimit: Long,
-    val data: String?,
+    val data: String?, // base64 encoded
     val signature: String,
     val sourceShard: Long,
     val destinationShard: Long,
     val blockNonce: Long,
+    val timestamp: Long,
     val miniBlockHash: String?,
     val blockHash: String?,
     val status: String,
-    val hyperblockNonce: Long?
-)
+    val hyperblockNonce: Long?,
+    val smartContractResults: List<ScResult>?
+) {
+
+    data class ScResult(
+        val hash: String?,
+        val nonce: Long,
+        val value: BigInteger,
+        val receiver: Address,
+        val sender: Address,
+        val data: String?, // not base64 encoded
+        val prevTxHash: String,
+        val originalTxHash: String,
+        val gasLimit: Long,
+        val gasPrice: Long,
+        val callType: String
+    )
+
+}

--- a/erdkotlin/src/main/java/com/elrond/erdkotlin/domain/transaction/models/TransactionInfo.kt
+++ b/erdkotlin/src/main/java/com/elrond/erdkotlin/domain/transaction/models/TransactionInfo.kt
@@ -28,7 +28,6 @@ data class TransactionInfo(
     val hyperblockNonce: Long?,
     val smartContractResults: List<ScResult>?
 ) {
-
     data class ScResult(
         val hash: String?,
         val nonce: Long,
@@ -42,5 +41,4 @@ data class TransactionInfo(
         val gasPrice: Long,
         val callType: String
     )
-
 }

--- a/erdkotlin/src/main/java/com/elrond/erdkotlin/domain/transaction/models/TransactionOnNetwork.kt
+++ b/erdkotlin/src/main/java/com/elrond/erdkotlin/domain/transaction/models/TransactionOnNetwork.kt
@@ -24,28 +24,5 @@ data class TransactionOnNetwork(
     val round: Long,
     val searchOrder: Long,
     val fee: String,
-    val scResults: List<ScResult>?,
     val hyperblockNonce: Long?
-) {
-
-    data class ScResult(
-        val hash: String?,
-        val nonce: Long,
-        val gasLimit: Long,
-        val gasPrice: Long,
-        val value: BigInteger,
-        val sender: String,
-        val receiver: String,
-        val relayedValue: String?,
-        val data: String?,
-        val prevTxHash: String,
-        val originalTxHash: String,
-        val callType: String,
-        val relayerAddress: String?,
-        val code: String?,
-        val codeMetadata: String?,
-        val returnMessage: String?,
-        val originalSender: String?,
-    )
-
-}
+)


### PR DESCRIPTION
**Changelog**

This PR updates the following models
- Add `smartContractResults` field to `TransactionInfo` in order to handle `withResults=true` parameter for [transaction/:txHash](https://docs.elrond.com/sdk-and-tools/rest-api/transactions/#get-transaction)
- Add `timestamp` field to `TransactionInfo`
- Remove `scResults` from the response of [address/:bech32Address/transactions](https://docs.elrond.com/sdk-and-tools/rest-api/addresses/#get-address-transactions) since it is not returned anymore.

This PR also adds
 - `extraGasLimit` parameter  to `TransferEsdtUsecase` allowing to add extra gas when interacting with a smartcontract.