### PR TITLE
Erdkotlin to version 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 Changelog
 ============
 
+## [0.6.0] - xx.xx.2021
+- ErdKotlin is now accessible as a gradle dependency
+- Model update
+  - Add `smartContractResults` field to `TransactionInfo` in order to handle `withResults=true` parameter for [transaction/:txHash](https://docs.elrond.com/sdk-and-tools/rest-api/transactions/#get-transaction)
+  - Add `timestamp` field to `TransactionInfo`
+  - Remove `scResults` from the response of [address/:bech32Address/transactions](https://docs.elrond.com/sdk-and-tools/rest-api/addresses/#get-address-transactions) since it is not returned anymore.
+- add `extraGasLimit` parameter  to `TransferEsdtUsecase` allowing to add extra gas when interacting with a smartcontract.
+- Automatically decode the data field from `TransactionInfo` and `TransactionOnNetwork`
+
 ## [0.5.0] - 30.06.2021
 - implement ESDT API
   - Get all ESDT tokens for an address

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 Changelog
 ============
 
-## [0.6.0] - xx.xx.2021
+## [0.6.0] - 22.10.2021
 - ErdKotlin is now accessible as a gradle dependency
 - Model update
   - Add `smartContractResults` field to `TransactionInfo` in order to handle `withResults=true` parameter for [transaction/:txHash](https://docs.elrond.com/sdk-and-tools/rest-api/transactions/#get-transaction)

--- a/README.md
+++ b/README.md
@@ -106,9 +106,16 @@ ErdSdk.elrondHttpClientBuilder.apply {
 }
 ```
 
-## Build
-The SDK is not yet uploaded to a maven repository  
-You can build the jar from the sources by running `mvn package`
+## Download
+```
+repositories {
+    maven { url 'https://jitpack.io' }
+}
+
+dependencies {
+    implementation "com.github.ElrondNetwork:elrond-sdk-erdkotlin:0.6.0"
+}
+```
 
 ## Sample App
 For a complete example you can checkout this [sample application](https://github.com/Alexandre-saddour/ElrondKotlinSampleApp)

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 
 ext {
-    pomVersion = '0.5.1'
+    pomVersion = '0.6.0'
     pomGroupID = "com.elrond.erdkotlin"
 }
 


### PR DESCRIPTION
This PR simply update
- README
- CHANGELOG
- Sdk version number to 0.6.0

Please merge this PR **after** https://github.com/ElrondNetwork/elrond-sdk-erdkotlin/pull/8 and https://github.com/ElrondNetwork/elrond-sdk-erdkotlin/pull/9